### PR TITLE
Reusable workflows for build process

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -164,3 +164,6 @@ indent_size = 2
 indent_size = 2
 charset = utf-8-bom
 insert_final_newline = true
+
+[*.yml]
+indent_size = 2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,11 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
       DOTNET_NOLOGO: true
+      # Assuming a tag number will be used here only in cases when an artifact
+      # should be generated. In all other cases, this will be the branch name
+      # which may or may not be a valid Windows filename (branches with
+      # slashes, for example) however an artifact won't be generated in those
+      # cases.
       ARTIFACT_NAME: TeamsStatusPub-${{ github.ref_name }}.zip
       PUBLISH_DIR: publish
 
@@ -31,6 +36,7 @@ jobs:
           dotnet-version: 7.0.x
 
       # Existing version number isn't expected to have a revision number.
+      # Expecting "x.y.z" string. This will append ".build" to it.
       - name: Add build number to version string
         run: |
           # Need absolute path for saving later.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: artifact
-          path: |
-            ${{ env.ARTIFACT_NAME }}
-            ${{ env.PUBLISH_DIR }}
+          path: ${{ env.ARTIFACT_NAME }}
           retention-days: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,7 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
       DOTNET_NOLOGO: true
-      #ARTIFACT_NAME: TeamsStatusPub-${{ github.ref_name }}.zip
-      ARTIFACT_NAME: TeamsStatusPub-11.22.33.zip
+      ARTIFACT_NAME: TeamsStatusPub-${{ github.ref_name }}.zip
       PUBLISH_DIR: publish
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,8 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
       DOTNET_NOLOGO: true
-      ARTIFACT_NAME: TeamsStatusPub-${{ github.ref_name }}.zip
+      #ARTIFACT_NAME: TeamsStatusPub-${{ github.ref_name }}.zip
+      ARTIFACT_NAME: TeamsStatusPub-11.22.33.zip
       PUBLISH_DIR: publish
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,10 @@ on:
         description: 'Whether or not to create the artifact'
         required: true
         type: boolean
+      artifactVersion:
+        description: 'Version string to append to artifact file name'
+        required: true
+        type: string
 
 jobs:
   build:
@@ -18,12 +22,7 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
       DOTNET_NOLOGO: true
-      # Assuming a tag number will be used here only in cases when an artifact
-      # should be generated. In all other cases, this will be the branch name
-      # which may or may not be a valid Windows filename (branches with
-      # slashes, for example) however an artifact won't be generated in those
-      # cases.
-      ARTIFACT_NAME: TeamsStatusPub-${{ github.ref_name }}.zip
+      ARTIFACT_NAME: TeamsStatusPub-${{ inputs.artifactVersion }}.zip
       PUBLISH_DIR: publish
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
       DOTNET_NOLOGO: true
+      ARTIFACT_NAME: TeamsStatusPub-${{ github.ref_name }}.zip
       PUBLISH_DIR: publish
 
     steps:
@@ -62,10 +63,16 @@ jobs:
           --self-contained false
           src/TeamsStatusPub/TeamsStatusPub.csproj
 
-      - name: Artifact
+      - name: Zip artifact
+        if: ${{ inputs.createArtifact }}
+        run: Compress-Archive -Path ${{ env.PUBLISH_DIR }}\* -DestinationPath ${{ env.ARTIFACT_NAME }}
+
+      - name: Upload artifact
         if: ${{ inputs.createArtifact }}
         uses: actions/upload-artifact@v3
         with:
           name: artifact
-          path: ${{ env.PUBLISH_DIR }}
+          path: |
+            ${{ env.ARTIFACT_NAME }}
+            ${{ env.PUBLISH_DIR }}
           retention-days: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,65 @@
+name: Build and test solution
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    name: Windows Forms
+    runs-on: windows-latest
+    timeout-minutes: 10
+
+    env:
+      DOTNET_CLI_TELEMETRY_OPTOUT: true
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+      DOTNET_NOLOGO: true
+      PUBLISH_DIR: publish
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3.0.3
+        with:
+          dotnet-version: 7.0.x
+
+      # Existing version number isn't expected to have a revision number.
+      - name: Add build number to version string
+        run: |
+          # Need absolute path for saving later.
+          $csproj = "src/TeamsStatusPub/TeamsStatusPub.csproj" | Resolve-Path
+          $xml = [xml](Get-Content $csproj)
+          $xml.Project.PropertyGroup.Version += ".${env:GITHUB_RUN_NUMBER}"
+          Write-Host "Setting assembly version to $($xml.Project.PropertyGroup.Version)"
+          $xml.Save($csproj)
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Test
+        run: dotnet test --no-build --verbosity normal --configuration Release
+
+      - name: Create artifact
+        if: startsWith(github.ref, 'refs/tags/')
+        run: >
+          dotnet publish
+          --configuration Release
+          --runtime win-x64
+          --output ${{ env.PUBLISH_DIR }}
+          --no-restore
+          -property:PublishSingleFile=true
+          -property:DebugType=None
+          -property:DebugSymbols=false
+          --self-contained false
+          src/TeamsStatusPub/TeamsStatusPub.csproj
+
+      - name: Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifact
+          path: ${{ env.PUBLISH_DIR }}
+          retention-days: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,11 @@ name: Build and test solution
 
 on:
   workflow_call:
+    inputs:
+      createArtifact:
+        description: 'Whether or not to create the artifact'
+        required: true
+        type: boolean
 
 jobs:
   build:
@@ -44,7 +49,7 @@ jobs:
         run: dotnet test --no-build --verbosity normal --configuration Release
 
       - name: Create artifact
-        if: startsWith(github.ref, 'refs/tags/')
+        if: ${{ inputs.createArtifact }}
         run: >
           dotnet publish
           --configuration Release
@@ -58,6 +63,7 @@ jobs:
           src/TeamsStatusPub/TeamsStatusPub.csproj
 
       - name: Artifact
+        if: ${{ inputs.createArtifact }}
         uses: actions/upload-artifact@v3
         with:
           name: artifact

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,20 +5,17 @@ on:
     paths-ignore:
       - '**.md'
 
-env:
-  CREATE_RELEASE: ${{ startsWith(github.ref, 'refs/tags/') }}
-
 jobs:
   build:
     name: Build and Test
     uses: ./.github/workflows/build.yml
     with:
-      createArtifact: ${{ env.CREATE_RELEASE }}
+      createArtifact: ${{ startsWith(github.ref, 'refs/tags/') }}
 
   release:
     name: Create Release
     needs: build
-    if: ${{ env.CREATE_RELEASE }}
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     steps:
       - name: Download artifact
@@ -28,7 +25,7 @@ jobs:
           path: publish
 
       - name: Create GitHub release
-        if: ${{ env.CREATE_RELEASE }}
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: softprops/action-gh-release@v1
         with:
           files: publish

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ jobs:
     name: Create Release
     needs: build
     if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
       - '**.md'
 
 env:
-  CREATE_RELEASE: startsWith(github.ref, 'refs/tags/')
+  CREATE_RELEASE: ${{ startsWith(github.ref, 'refs/tags/') }}
 
 jobs:
   build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Build and Test
     uses: ./.github/workflows/build.yml
     with:
-      createArtifact: ${{ startsWith(github.ref, 'refs/tags/') }}
+      createArtifact: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
   release:
     name: Create Release
@@ -28,5 +28,5 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: softprops/action-gh-release@v1
         with:
-          files: publish
+          files: publish/*.zip
           name: TeamsStatusPub ${{ github.ref_name }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,66 +7,23 @@ on:
 
 jobs:
   build:
-    name: Windows Forms
-    runs-on: windows-latest
-    timeout-minutes: 10
+    name: Build and Test
+    uses: ./.github/workflows/build.yml
 
-    env:
-      DOTNET_CLI_TELEMETRY_OPTOUT: true
-      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-      DOTNET_NOLOGO: true
-      ARTIFACT_NAME: TeamsStatusPub-${{ github.ref_name }}.zip
-      PUBLISH_DIR: publish
-
+  release:
+    name: Create Release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v3.0.3
+      - name: Download artifact
+        uses: actions/download-artifact@v3
         with:
-          dotnet-version: 7.0.x
-
-      # Existing version number isn't expected to have a revision number.
-      - name: Add build number to version string
-        run: |
-          # Need absolute path for saving later.
-          $csproj = "src/TeamsStatusPub/TeamsStatusPub.csproj" | Resolve-Path
-          $xml = [xml](Get-Content $csproj)
-          $xml.Project.PropertyGroup.Version += ".${env:GITHUB_RUN_NUMBER}"
-          Write-Host "Setting assembly version to $($xml.Project.PropertyGroup.Version)"
-          $xml.Save($csproj)
-
-      - name: Restore dependencies
-        run: dotnet restore
-
-      - name: Build
-        run: dotnet build --no-restore --configuration Release
-
-      - name: Test
-        run: dotnet test --no-build --verbosity normal --configuration Release
-
-      - name: Create artifact
-        if: startsWith(github.ref, 'refs/tags/')
-        run: >
-          dotnet publish
-          --configuration Release
-          --runtime win-x64
-          --output ${{ env.PUBLISH_DIR }}
-          --no-restore
-          -property:PublishSingleFile=true
-          -property:DebugType=None
-          -property:DebugSymbols=false
-          --self-contained false
-          src/TeamsStatusPub/TeamsStatusPub.csproj
-
-      - name: Zip artifact
-        if: startsWith(github.ref, 'refs/tags/')
-        run: Compress-Archive -Path ${{ env.PUBLISH_DIR }}\* -DestinationPath ${{ env.ARTIFACT_NAME }}
+          name: artifact
+          path: publish
 
       - name: Create GitHub release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
-          files: ${{ env.ARTIFACT_NAME }}
+          files: publish
           name: TeamsStatusPub ${{ github.ref_name }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,12 +10,12 @@ jobs:
     name: Build and Test
     uses: ./.github/workflows/build.yml
     with:
-      createArtifact: ${{ startsWith(github.ref, 'refs/tags/') }}
+      createArtifact: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
   release:
     name: Create Release
     needs: build
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     steps:
       - name: Download artifact
@@ -25,7 +25,7 @@ jobs:
           path: publish
 
       - name: Create GitHub release
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: softprops/action-gh-release@v1
         with:
           files: publish

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,15 +5,20 @@ on:
     paths-ignore:
       - '**.md'
 
+env:
+  CREATE_RELEASE: startsWith(github.ref, 'refs/tags/')
+
 jobs:
   build:
     name: Build and Test
     uses: ./.github/workflows/build.yml
+    with:
+      createArtifact: ${{ env.CREATE_RELEASE }}
 
   release:
     name: Create Release
     needs: build
-    if: startsWith(github.ref, 'refs/tags/')
+    if: ${{ env.CREATE_RELEASE }}
     runs-on: ubuntu-latest
     steps:
       - name: Download artifact
@@ -23,7 +28,7 @@ jobs:
           path: publish
 
       - name: Create GitHub release
-        if: startsWith(github.ref, 'refs/tags/')
+        if: ${{ env.CREATE_RELEASE }}
         uses: softprops/action-gh-release@v1
         with:
           files: publish

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,12 +10,12 @@ jobs:
     name: Build and Test
     uses: ./.github/workflows/build.yml
     with:
-      createArtifact: ${{ !startsWith(github.ref, 'refs/tags/') }}
+      createArtifact: ${{ startsWith(github.ref, 'refs/tags/') }}
 
   release:
     name: Create Release
     needs: build
-    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     steps:
       - name: Download artifact
@@ -25,7 +25,7 @@ jobs:
           path: publish
 
       - name: Create GitHub release
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: softprops/action-gh-release@v1
         with:
           files: publish

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Build and Test
     uses: ./.github/workflows/build.yml
     with:
-      createArtifact: ${{ !startsWith(github.ref, 'refs/tags/') }}
+      createArtifact: ${{ startsWith(github.ref, 'refs/tags/') }}
 
   release:
     name: Create Release
@@ -20,13 +20,10 @@ jobs:
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v3
-        with:
-          name: artifact
-          path: publish
 
       - name: Create GitHub release
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: softprops/action-gh-release@v1
         with:
-          files: publish/*.zip
+          files: '*.zip'
           name: TeamsStatusPub ${{ github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,14 +21,8 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v3
 
-      - name: Show files from downloaded artifact
-        run: ls -l
-
-      - name: Show files in downloaded artifact
-        run: ls -l artifact/
-
       - name: Create GitHub release
         uses: softprops/action-gh-release@v1
         with:
-          files: '*.zip'
+          files: 'artifact/*.zip'
           name: TeamsStatusPub ${{ github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,13 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v3
 
+      - name: Show files from downloaded artifact
+        run: ls -l
+
+      - name: Show files in downloaded artifact
+        run: ls -l artifact/
+
       - name: Create GitHub release
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: softprops/action-gh-release@v1
         with:
           files: '*.zip'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       createArtifact: ${{ startsWith(github.ref, 'refs/tags/') }}
+      artifactVersion: ${{ github.ref_name }}
 
   release:
     name: Create Release

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       createArtifact: true
+      artifactVersion: codesql
 
   analyze:
     name: Analyze

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,71 +1,37 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL"
 
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
   schedule:
     - cron: '36 6 * * 6'
 
 jobs:
+  build:
+    name: Build and Test
+    uses: ./.github/workflows/build.yml
+
   analyze:
     name: Analyze
     runs-on: windows-latest
+    needs: build
     permissions:
       actions: read
       contents: read
       security-events: write
 
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'csharp' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Use only 'java' to analyze code written in Java, Kotlin or both
-        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: artifact
 
-      # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
-          languages: ${{ matrix.language }}
-          # If you wish to specify custom queries, you can do so here or in a config file.
-          # By default, queries listed here will override any specified in a config file.
-          # Prefix the list here with "+" to use these queries and those in the config file.
-
-          # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-          # queries: security-extended,security-and-quality
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v3.0.3
-        with:
-          dotnet-version: 7.0.x
-
-      - name: Restore dependencies
-        run: dotnet restore
-
-      - name: Build
-        run: dotnet build --no-restore --configuration Release
+          languages: "csharp"
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
         with:
-          category: "/language:${{matrix.language}}"
+          category: "/language:csharp"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,4 @@
-name: "CodeQL"
+name: CodeQL
 
 on:
   push:
@@ -6,32 +6,39 @@ on:
       - '**.md'
 
 jobs:
-  build:
-    name: Build and Test
-    uses: ./.github/workflows/build.yml
-    with:
-      createArtifact: true
-      artifactVersion: codesql
-
   analyze:
     name: Analyze
     runs-on: windows-latest
-    needs: build
     permissions:
       actions: read
       contents: read
       security-events: write
+    env:
+      DOTNET_CLI_TELEMETRY_OPTOUT: true
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+      DOTNET_NOLOGO: true
 
     steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v3
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3.0.3
+        with:
+          dotnet-version: 7.0.x
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
-          languages: "csharp"
+          languages: csharp
 
-      - name: Perform CodeQL Analysis
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v2
         with:
           category: "/language:csharp"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,8 +25,6 @@ jobs:
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v3
-        with:
-          name: artifact
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     name: Build and Test
     uses: ./.github/workflows/build.yml
+    with:
+      createArtifact: true
 
   analyze:
     name: Analyze

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,8 +2,9 @@ name: CodeQL
 
 on:
   push:
-    paths-ignore:
-      - '**.md'
+    branches: [ "main" ]
+  schedule:
+    - cron: '36 6 * * 6'
 
 jobs:
   analyze:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,8 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
-  schedule:
-    - cron: '36 6 * * 6'
+    paths-ignore:
+      - '**.md'
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Teams Status Pub
 
-[![Continuous integration](https://github.com/tetsuo13/TeamsStatusPub/actions/workflows/ci.yaml/badge.svg)](https://github.com/tetsuo13/TeamsStatusPub/actions/workflows/ci.yaml) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![release](https://img.shields.io/github/release/tetsuo13/TeamsStatusPub.svg)](https://github.com/tetsuo13/TeamsStatusPub/releases)
+[![Continuous integration](https://github.com/tetsuo13/TeamsStatusPub/actions/workflows/ci.yml/badge.svg)](https://github.com/tetsuo13/TeamsStatusPub/actions/workflows/ci.yml) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![release](https://img.shields.io/github/release/tetsuo13/TeamsStatusPub.svg)](https://github.com/tetsuo13/TeamsStatusPub/releases)
 
 <img src="src/TeamsStatusPub/logo.png" width="100" alt="Logo" align="right" />
 


### PR DESCRIPTION
Since the introduction of CodeQL the build process has been duplicated between that and the CI workflows. This PR moves those steps out to a reusable workflow that can be called on instead.

Also changes CodeQL workflow to not trigger for PRs against `main` (it's probably overkill).