### PR TITLE
Fix Serilog exception when publishing as single-file app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Teams Status Pub Changelog
 
+## Unreleased
+
+- Fixed crash on launch introduced in previous version ([#49](https://github.com/tetsuo13/TeamsStatusPub/issues/49))
+
 ## 1.3.0 (2023-05-22)
 
 - Fixed minimized window showing in bottom-left of screen ([#31](https://github.com/tetsuo13/TeamsStatusPub/issues/31))

--- a/src/TeamsStatusPub/Configuration/LoggingConfiguration.cs
+++ b/src/TeamsStatusPub/Configuration/LoggingConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Serilog;
+using Serilog.Settings.Configuration;
 
 namespace TeamsStatusPub.Configuration;
 
@@ -24,6 +25,10 @@ internal static class LoggingConfiguration
     /// </summary>
     public static void CreateDefaultLogger()
     {
+        // Need to explicitly specify assemblies that contain sinks otherwise
+        // an exception is thrown when launching as a single-file app.
+        var readerOptions = new ConfigurationReaderOptions(typeof(FileLoggerConfigurationExtensions).Assembly);
+
         // Allow Serilog config to be modified by appsettings file at runtime.
         var configuration = new ConfigurationBuilder()
             .AddJsonFile("appsettings.json")
@@ -31,7 +36,7 @@ internal static class LoggingConfiguration
 
         Log.Logger = new LoggerConfiguration()
             .WriteTo.File($"{nameof(TeamsStatusPub).ToLower()}.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7)
-            .ReadFrom.Configuration(configuration)
+            .ReadFrom.Configuration(configuration, readerOptions)
             .CreateLogger();
     }
 }

--- a/src/TeamsStatusPub/Program.cs
+++ b/src/TeamsStatusPub/Program.cs
@@ -14,23 +14,26 @@ internal static class Program
     [STAThread]
     public static void Main()
     {
-        LoggingConfiguration.CreateDefaultLogger();
-
-        var host = Host.CreateDefaultBuilder()
-            .ConfigureAppLogging()
-            .ConfigureAppServices()
-            .Build();
-
-        ApplicationConfiguration.Initialize();
-
         try
         {
+            LoggingConfiguration.CreateDefaultLogger();
+
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureAppLogging()
+                .ConfigureAppServices()
+                .Build();
+
+            ApplicationConfiguration.Initialize();
+
             Log.Information("Starting application");
+
             Application.Run((Form)host.Services.GetRequiredService<IMainForm>());
         }
         catch (Exception e)
         {
             Log.Fatal(e, "Application terminated unexpectedly");
+            MessageBox.Show($"An unexpected exception was encountered:\n{e.Message}",
+                "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
         finally
         {


### PR DESCRIPTION
Surround entire application setup and run section in try-catch block in case there's an error during setting up logging or other services so that a message box can be shown. This isn't ideal but logging may not be available if it was the cause of the error and we don't want silent crashes.

Couldn't find a suitable way of unit testing this bug unfortunately.