### PR TITLE
Replace Moq with NSubstitute

### DIFF
--- a/tests/TeamsStatusPub.IntegrationTests/Services/AvailabilityHandlers/MicrosoftTeams/LogFileReaderTests.cs
+++ b/tests/TeamsStatusPub.IntegrationTests/Services/AvailabilityHandlers/MicrosoftTeams/LogFileReaderTests.cs
@@ -1,9 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 using TeamsStatusPub.Services.AvailabilityHandlers.MicrosoftTeams;
 using Xunit;
 
@@ -149,12 +148,12 @@ public static class LogFileReaderTests
     {
         Assert.NotEmpty(linesOfInterest);
         Assert.Equal(expectedCount, linesOfInterest.Count);
-        Assert.True(linesOfInterest.All(LogFileReader.ContainsEventToken));
+        Assert.True(linesOfInterest.TrueForAll(LogFileReader.ContainsEventToken));
     }
 
     private static LogFileReader GetReader()
     {
-        var logger = new Mock<ILogger<LogFileReader>>();
-        return new LogFileReader(logger.Object);
+        var logger = Substitute.For<ILogger<LogFileReader>>();
+        return new LogFileReader(logger);
     }
 }

--- a/tests/TeamsStatusPub.IntegrationTests/TeamsStatusPub.IntegrationTests.csproj
+++ b/tests/TeamsStatusPub.IntegrationTests/TeamsStatusPub.IntegrationTests.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/TeamsStatusPub.IntegrationTests/packages.lock.json
+++ b/tests/TeamsStatusPub.IntegrationTests/packages.lock.json
@@ -12,13 +12,13 @@
           "Microsoft.TestPlatform.TestHost": "17.7.1"
         }
       },
-      "Moq": {
+      "NSubstitute": {
         "type": "Direct",
-        "requested": "[4.20.69, )",
-        "resolved": "4.20.69",
-        "contentHash": "8P/oAUOL8ZVyXnzBBcgdhTsOD1kQbAWfOcMI7KDQO3HqQtzB/0WYLdnMa4Jefv8nu/MQYiiG0IuoJdvG0v0Nig==",
+        "requested": "[5.0.0, )",
+        "resolved": "5.0.0",
+        "contentHash": "CWGy4oXvcJcZzL7m5Rr/eMSejFXMDq1RRMlsbL6eltS3AuN/d8GH3ZzUcuStQcCSlcx+hpsgTxdnb3lhozWG6w==",
         "dependencies": {
-          "Castle.Core": "5.1.1"
+          "Castle.Core": "5.0.0"
         }
       },
       "xunit": {
@@ -40,8 +40,8 @@
       },
       "Castle.Core": {
         "type": "Transitive",
-        "resolved": "5.1.1",
-        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "resolved": "5.0.0",
+        "contentHash": "edc8jjyXqzzy8jFdhs36FZdwmlDDTgqPb2Zy1Q5F/f2uAc88bu/VS/0Tpvgupmpl9zJOvOo5ZizVANb0ltN1NQ==",
         "dependencies": {
           "System.Diagnostics.EventLog": "6.0.0"
         }

--- a/tests/TeamsStatusPub.UnitTests/Presenters/AboutFormPresenterTests.cs
+++ b/tests/TeamsStatusPub.UnitTests/Presenters/AboutFormPresenterTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using Microsoft.Extensions.Options;
-using Moq;
+using NSubstitute;
 using TeamsStatusPub.Models;
 using TeamsStatusPub.Presenters;
 using TeamsStatusPub.Services;
@@ -16,12 +16,12 @@ public static class AboutFormPresenterTests
     [InlineData(false, "busy")]
     public static void LastTeamsStatus_IsAvailable_ReturnsBusyStatus(bool isAvailable, string expectedStatus)
     {
-        var appInfo = new Mock<IAppInfo>();
+        var appInfo = Substitute.For<IAppInfo>();
         var runtimeSettings = Options.Create(new RuntimeSettings());
-        var availabilityHandler = new Mock<IAvailabilityHandler>();
-        availabilityHandler.Setup(x => x.IsAvailable()).Returns(isAvailable);
+        var availabilityHandler = Substitute.For<IAvailabilityHandler>();
+        availabilityHandler.IsAvailable().Returns(isAvailable);
 
-        var presenter = new AboutFormPresenter(appInfo.Object, runtimeSettings, availabilityHandler.Object);
+        var presenter = new AboutFormPresenter(appInfo, runtimeSettings, availabilityHandler);
 
         Assert.Equal(expectedStatus, presenter.LastTeamsStatus);
     }
@@ -29,15 +29,15 @@ public static class AboutFormPresenterTests
     [Fact]
     public static void ListenUrl_RuntimeSettings_ShowsListenAddressAndPort()
     {
-        var appInfo = new Mock<IAppInfo>();
+        var appInfo = Substitute.For<IAppInfo>();
         var runtimeSettings = Options.Create(new RuntimeSettings
         {
             ListenAddress = "10.11.12.13",
             ListenPort = 12345
         });
-        var availabilityHandler = new Mock<IAvailabilityHandler>();
+        var availabilityHandler = Substitute.For<IAvailabilityHandler>();
 
-        var presenter = new AboutFormPresenter(appInfo.Object, runtimeSettings, availabilityHandler.Object);
+        var presenter = new AboutFormPresenter(appInfo, runtimeSettings, availabilityHandler);
 
         Assert.Equal($"http://{runtimeSettings.Value.ListenAddress}:{runtimeSettings.Value.ListenPort}/",
             presenter.ListenUrl);
@@ -47,8 +47,8 @@ public static class AboutFormPresenterTests
     public static void ApplicationName_FromAppInfo()
     {
         var expected = "2023 Acme Corp, LLC";
-        var appInfo = new Mock<IAppInfo>();
-        appInfo.Setup(x => x.ApplicationName).Returns(expected);
+        var appInfo = Substitute.For<IAppInfo>();
+        appInfo.ApplicationName.Returns(expected);
 
         TestPropertyFromAppInfo(appInfo,
             (IAboutFormPresenter presenter) => Assert.Equal(expected, presenter.ApplicationName));
@@ -58,8 +58,8 @@ public static class AboutFormPresenterTests
     public static void Copright_FromAppInfo()
     {
         var expected = "2023 Acme Corp, LLC";
-        var appInfo = new Mock<IAppInfo>();
-        appInfo.Setup(x => x.Copyright).Returns(expected);
+        var appInfo = Substitute.For<IAppInfo>();
+        appInfo.Copyright.Returns(expected);
 
         TestPropertyFromAppInfo(appInfo,
             (IAboutFormPresenter presenter) => Assert.Equal(expected, presenter.Copyright));
@@ -69,8 +69,8 @@ public static class AboutFormPresenterTests
     public static void WebsiteUrl_FromAppInfo()
     {
         var expected = "https://youtu.be/dQw4w9WgXcQ";
-        var appInfo = new Mock<IAppInfo>();
-        appInfo.Setup(x => x.WebsiteUrl).Returns(expected);
+        var appInfo = Substitute.For<IAppInfo>();
+        appInfo.WebsiteUrl.Returns(expected);
 
         TestPropertyFromAppInfo(appInfo,
             (IAboutFormPresenter presenter) => Assert.Equal(expected, presenter.WebsiteUrl));
@@ -80,20 +80,19 @@ public static class AboutFormPresenterTests
     public static void Version_FromAppInfo()
     {
         var expected = "1.2.3";
-        var appInfo = new Mock<IAppInfo>();
-        appInfo.Setup(x => x.Version).Returns(expected);
+        var appInfo = Substitute.For<IAppInfo>();
+        appInfo.Version.Returns(expected);
 
         TestPropertyFromAppInfo(appInfo,
             (IAboutFormPresenter presenter) => Assert.Equal(expected, presenter.Version));
     }
 
-    private static void TestPropertyFromAppInfo(Mock<IAppInfo> appInfo,
-        Action<IAboutFormPresenter> value)
+    private static void TestPropertyFromAppInfo(IAppInfo appInfo, Action<IAboutFormPresenter> value)
     {
         var runtimeSettings = Options.Create(new RuntimeSettings());
-        var availabilityHandler = new Mock<IAvailabilityHandler>();
+        var availabilityHandler = Substitute.For<IAvailabilityHandler>();
 
-        var presenter = new AboutFormPresenter(appInfo.Object, runtimeSettings, availabilityHandler.Object);
+        var presenter = new AboutFormPresenter(appInfo, runtimeSettings, availabilityHandler);
 
         value(presenter);
     }

--- a/tests/TeamsStatusPub.UnitTests/Services/HttpProviderTests.cs
+++ b/tests/TeamsStatusPub.UnitTests/Services/HttpProviderTests.cs
@@ -2,7 +2,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Moq;
+using NSubstitute;
 using TeamsStatusPub.Models;
 using TeamsStatusPub.Services;
 using Xunit;
@@ -52,14 +52,14 @@ public static class HttpProviderTests
 
     private static HttpProvider CreateProvider(string? listenAddress, int listenPort)
     {
-        var logger = new Mock<ILogger<HttpProvider>>();
-        var scopeFactory = new Mock<IServiceScopeFactory>();
+        var logger = Substitute.For<ILogger<HttpProvider>>();
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
         var runtimeSettings = Options.Create(new RuntimeSettings
         {
             ListenAddress = listenAddress,
             ListenPort = listenPort
         });
 
-        return new HttpProvider(logger.Object, runtimeSettings, scopeFactory.Object);
+        return new HttpProvider(logger, runtimeSettings, scopeFactory);
     }
 }

--- a/tests/TeamsStatusPub.UnitTests/Services/HttpServers/HttpAvailabilitySessionTests.cs
+++ b/tests/TeamsStatusPub.UnitTests/Services/HttpServers/HttpAvailabilitySessionTests.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
-using Moq;
 using NetCoreServer;
+using NSubstitute;
 using TeamsStatusPub.Services.HttpServers;
 using Xunit;
 
@@ -57,10 +57,10 @@ public static class HttpAvailabilitySessionTests
     private static HttpAvailabilitySession CreateSession(bool? previousAvailabilityResult,
         bool currentAvailabilityResult)
     {
-        var logger = new Mock<ILogger<HttpAvailabilitySession>>();
+        var logger = Substitute.For<ILogger<HttpAvailabilitySession>>();
         var httpServer = new HttpServer("127.0.0.1", 12345);
 
-        return new HttpAvailabilitySession(logger.Object, httpServer,
+        return new HttpAvailabilitySession(logger, httpServer,
             previousAvailabilityResult, currentAvailabilityResult);
     }
 }

--- a/tests/TeamsStatusPub.UnitTests/TeamsStatusPub.UnitTests.csproj
+++ b/tests/TeamsStatusPub.UnitTests/TeamsStatusPub.UnitTests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/TeamsStatusPub.UnitTests/packages.lock.json
+++ b/tests/TeamsStatusPub.UnitTests/packages.lock.json
@@ -12,13 +12,13 @@
           "Microsoft.TestPlatform.TestHost": "17.7.1"
         }
       },
-      "Moq": {
+      "NSubstitute": {
         "type": "Direct",
-        "requested": "[4.20.69, )",
-        "resolved": "4.20.69",
-        "contentHash": "8P/oAUOL8ZVyXnzBBcgdhTsOD1kQbAWfOcMI7KDQO3HqQtzB/0WYLdnMa4Jefv8nu/MQYiiG0IuoJdvG0v0Nig==",
+        "requested": "[5.0.0, )",
+        "resolved": "5.0.0",
+        "contentHash": "CWGy4oXvcJcZzL7m5Rr/eMSejFXMDq1RRMlsbL6eltS3AuN/d8GH3ZzUcuStQcCSlcx+hpsgTxdnb3lhozWG6w==",
         "dependencies": {
-          "Castle.Core": "5.1.1"
+          "Castle.Core": "5.0.0"
         }
       },
       "xunit": {
@@ -40,8 +40,8 @@
       },
       "Castle.Core": {
         "type": "Transitive",
-        "resolved": "5.1.1",
-        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "resolved": "5.0.0",
+        "contentHash": "edc8jjyXqzzy8jFdhs36FZdwmlDDTgqPb2Zy1Q5F/f2uAc88bu/VS/0Tpvgupmpl9zJOvOo5ZizVANb0ltN1NQ==",
         "dependencies": {
           "System.Diagnostics.EventLog": "6.0.0"
         }


### PR DESCRIPTION
This PR replaces Moq due to privacy and data exfiltration issues. See https://github.com/moq/moq/issues/1372 for original discussion.