### PR TITLE
Faster builds by using older Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,8 @@ jobs:
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v3
-          with: dotnet-version: 8.x
+        with:
+          dotnet-version: 8.x
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build:
     name: Windows Forms
-    runs-on: windows-latest
+    runs-on: windows-2019
     timeout-minutes: 10
 
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,10 @@ jobs:
           Write-Host "Setting assembly version to $($xml.Project.PropertyGroup.Version)"
           $xml.Save($csproj)
 
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v3
+          with: dotnet-version: 8.x
+
       - name: Restore dependencies
         run: dotnet restore
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,8 @@ jobs:
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v3
-          with: dotnet-version: 8.x
+        with:
+          dotnet-version: 8.x
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,6 +30,10 @@ jobs:
         with:
           languages: csharp
 
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v3
+          with: dotnet-version: 8.x
+
       - name: Restore dependencies
         run: dotnet restore
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: windows-latest
+    runs-on: windows-2019
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
Using Windows 2019 instead of the latest version has a positive effect on speeding up the CI build. It isn't dramatic but can bring down the time spent in half.

Idea was based on this comment: https://github.com/actions/runner-images/issues/7320#issuecomment-1862639391